### PR TITLE
Create the mini-mail-auth crate

### DIFF
--- a/mini-mail-auth/Cargo.toml
+++ b/mini-mail-auth/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mini-mail-auth"
+description = "A minimal DKIM signing library for Rust, for those who just need to sign an email."
+version = "0.1.0"
+edition = "2021"
+authors = [ "Stalwart Labs LLC <hello@stalw.art>" ]
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/stalwartlabs/mail-auth"
+homepage = "https://github.com/stalwartlabs/mail-auth"
+keywords = ["dkim", "mail", "email", "sign"]
+categories = ["email", "authentication"]
+
+[dependencies]
+rsa = "0.9.8"
+sha2 = "0.10.6"
+base64 = "0.22.1"

--- a/mini-mail-auth/README.md
+++ b/mini-mail-auth/README.md
@@ -1,0 +1,33 @@
+# Mini Mail Auth
+
+`mini-mail-auth` is a lightweight Rust crate for developers who "just need to sign an email with a DKIM key".
+
+It is a heavily stripped-down version of the excellent [`mail-auth`](https://crates.io/crates/mail-auth) crate, containing only the necessary components for DKIM signing using RSA-SHA256. This results in a minimal dependency footprint, ideal for applications where email signing is the only requirement.
+
+## Usage
+
+This crate provides a simple function, `sign_email`, to handle DKIM signing with minimal setup.
+
+```rust
+use mini_mail_auth::sign_email;
+
+fn main() {
+    let private_key = "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----".to_string();
+    let email_to_sign = concat!(
+        "From: bill@example.com\r\n",
+        "To: jdoe@example.com\r\n",
+        "Subject: TPS Report\r\n",
+        "\r\n",
+        "I'm going to need those TPS reports ASAP."
+    );
+
+    let signed_email = sign_email(
+        email_to_sign,
+        "example.com",
+        "default",
+        &private_key,
+    );
+
+    println!("{}", signed_email);
+}
+```

--- a/mini-mail-auth/src/common/crypto.rs
+++ b/mini-mail-auth/src/common/crypto.rs
@@ -1,0 +1,121 @@
+use crate::{
+    dkim::Canonicalization,
+    Result, Error
+};
+use rsa::{pkcs1::DecodeRsaPrivateKey, Pkcs1v15Sign, RsaPrivateKey};
+use sha2::digest::Digest;
+use super::headers::{Writable, Writer};
+use std::marker::PhantomData;
+
+// --- Traits ---
+
+pub trait SigningKey {
+    type Hasher: HashImpl;
+    fn sign(&self, input: impl Writable) -> Result<Vec<u8>>;
+    fn hash(&self, data: impl Writable) -> HashOutput {
+        let mut hasher = <Self::Hasher as HashImpl>::hasher();
+        data.write(&mut hasher);
+        hasher.complete()
+    }
+    fn algorithm(&self) -> Algorithm;
+}
+
+pub trait HashContext: Writer + Sized {
+    fn complete(self) -> HashOutput;
+}
+
+pub trait HashImpl {
+    type Context: HashContext;
+    fn hasher() -> Self::Context;
+}
+
+// --- Enums and Structs ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Algorithm {
+    #[default]
+    RsaSha256,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub enum HashAlgorithm {
+    Sha256,
+}
+
+pub struct Sha256;
+
+#[non_exhaustive]
+pub enum HashOutput {
+    RustCryptoSha256(sha2::digest::Output<sha2::Sha256>),
+}
+
+// --- Implementations ---
+
+impl AsRef<[u8]> for HashOutput {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::RustCryptoSha256(output) => output.as_ref(),
+        }
+    }
+}
+
+impl From<Algorithm> for HashAlgorithm {
+    fn from(_: Algorithm) -> Self {
+        HashAlgorithm::Sha256
+    }
+}
+
+// --- RSA Key ---
+
+#[derive(Debug)]
+pub struct RsaKey<T> {
+    inner: RsaPrivateKey,
+    padding: PhantomData<T>,
+}
+
+impl<T: HashImpl> RsaKey<T> {
+    pub fn from_pkcs1_pem(private_key_pem: &str) -> Result<Self> {
+        let inner = RsaPrivateKey::from_pkcs1_pem(private_key_pem)?;
+        Ok(RsaKey { inner, padding: PhantomData })
+    }
+}
+
+impl SigningKey for RsaKey<Sha256> {
+    type Hasher = Sha256;
+
+    fn sign(&self, input: impl Writable) -> Result<Vec<u8>> {
+        let hash = self.hash(input);
+        self.inner
+            .sign(
+                Pkcs1v15Sign::new::<<Self::Hasher as HashImpl>::Context>(),
+                hash.as_ref(),
+            )
+            .map_err(|e| e.into())
+    }
+
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::RsaSha256
+    }
+}
+
+// --- SHA256 ---
+
+impl Writer for sha2::Sha256 {
+    fn write(&mut self, buf: &[u8]) {
+        self.update(buf);
+    }
+}
+
+impl HashImpl for Sha256 {
+    type Context = sha2::Sha256;
+    fn hasher() -> Self::Context {
+        <Self::Context as Digest>::new()
+    }
+}
+
+impl HashContext for sha2::Sha256 {
+    fn complete(self) -> HashOutput {
+        HashOutput::RustCryptoSha256(self.finalize())
+    }
+}

--- a/mini-mail-auth/src/common/headers.rs
+++ b/mini-mail-auth/src/common/headers.rs
@@ -1,0 +1,118 @@
+use std::{
+    iter::{Enumerate, Peekable},
+    slice::Iter,
+};
+
+pub trait HeaderStream<'x> {
+    fn next_header(&mut self) -> Option<(&'x [u8], &'x [u8])>;
+    fn body(&mut self) -> &'x [u8];
+}
+
+pub(crate) struct HeaderIterator<'x> {
+    message: &'x [u8],
+    iter: Peekable<Enumerate<Iter<'x, u8>>>,
+    start_pos: usize,
+}
+
+impl<'x> HeaderIterator<'x> {
+    pub fn new(message: &'x [u8]) -> Self {
+        HeaderIterator {
+            message,
+            iter: message.iter().enumerate().peekable(),
+            start_pos: 0,
+        }
+    }
+
+    pub fn body_offset(&mut self) -> Option<usize> {
+        self.iter.peek().map(|(pos, _)| *pos)
+    }
+}
+
+impl<'x> HeaderStream<'x> for HeaderIterator<'x> {
+    fn next_header(&mut self) -> Option<(&'x [u8], &'x [u8])> {
+        self.next()
+    }
+
+    fn body(&mut self) -> &'x [u8] {
+        self.body_offset()
+            .and_then(|offset| self.message.get(offset..))
+            .unwrap_or_default()
+    }
+}
+
+impl<'x> Iterator for HeaderIterator<'x> {
+    type Item = (&'x [u8], &'x [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut colon_pos = usize::MAX;
+        let mut last_ch = 0;
+
+        while let Some((pos, &ch)) = self.iter.next() {
+            if colon_pos == usize::MAX {
+                match ch {
+                    b':' => {
+                        colon_pos = pos;
+                    }
+                    b'\n' => {
+                        if last_ch == b'\r' || self.start_pos == pos {
+                            return None; // End of headers
+                        } else if self
+                            .iter
+                            .peek()
+                            .is_none_or(|(_, next_byte)| ![b' ', b'\t'].contains(next_byte))
+                        {
+                            let header_name = self.message.get(self.start_pos..pos + 1).unwrap_or_default();
+                            self.start_pos = pos + 1;
+                            return Some((header_name, b""));
+                        }
+                    }
+                    _ => (),
+                }
+            } else if ch == b'\n'
+                && self.iter.peek().is_none_or(|(_, next_byte)| ![b' ', b'\t'].contains(next_byte))
+            {
+                let header_name = self.message.get(self.start_pos..colon_pos).unwrap_or_default();
+                let header_value = self.message.get(colon_pos + 1..pos + 1).unwrap_or_default();
+                self.start_pos = pos + 1;
+                return Some((header_name, header_value));
+            }
+            last_ch = ch;
+        }
+        None
+    }
+}
+
+// --- Writer Traits ---
+
+pub trait HeaderWriter: Sized {
+    fn write_header(&self, writer: &mut impl Writer);
+    fn to_header(&self) -> String {
+        let mut buf = Vec::new();
+        self.write_header(&mut buf);
+        String::from_utf8(buf).unwrap()
+    }
+}
+
+pub trait Writable {
+    fn write(self, writer: &mut impl Writer);
+}
+
+impl Writable for &[u8] {
+    fn write(self, writer: &mut impl Writer) {
+        writer.write(self);
+    }
+}
+
+pub trait Writer {
+    fn write(&mut self, buf: &[u8]);
+    fn write_len(&mut self, buf: &[u8], len: &mut usize) {
+        self.write(buf);
+        *len += buf.len();
+    }
+}
+
+impl Writer for Vec<u8> {
+    fn write(&mut self, buf: &[u8]) {
+        self.extend(buf);
+    }
+}

--- a/mini-mail-auth/src/common/mod.rs
+++ b/mini-mail-auth/src/common/mod.rs
@@ -1,0 +1,2 @@
+pub mod crypto;
+pub mod headers;

--- a/mini-mail-auth/src/dkim/builder.rs
+++ b/mini-mail-auth/src/dkim/builder.rs
@@ -1,0 +1,69 @@
+use super::{Canonicalization, DkimSigner, Done, NeedDomain, NeedHeaders, NeedSelector};
+use crate::common::crypto::SigningKey;
+
+impl<T: SigningKey> DkimSigner<T> {
+    pub fn from_key(key: T) -> DkimSigner<T, NeedDomain> {
+        DkimSigner {
+            _state: Default::default(),
+            template: super::Signature {
+                v: 1,
+                a: key.algorithm(),
+                ..Default::default()
+            },
+            key,
+        }
+    }
+}
+
+impl<T: SigningKey> DkimSigner<T, NeedDomain> {
+    pub fn domain(mut self, domain: impl Into<String>) -> DkimSigner<T, NeedSelector> {
+        self.template.d = domain.into();
+        DkimSigner {
+            _state: Default::default(),
+            key: self.key,
+            template: self.template,
+        }
+    }
+}
+
+impl<T: SigningKey> DkimSigner<T, NeedSelector> {
+    pub fn selector(mut self, selector: impl Into<String>) -> DkimSigner<T, NeedHeaders> {
+        self.template.s = selector.into();
+        DkimSigner {
+            _state: Default::default(),
+            key: self.key,
+            template: self.template,
+        }
+    }
+}
+
+impl<T: SigningKey> DkimSigner<T, NeedHeaders> {
+    pub fn headers(
+        mut self,
+        headers: impl IntoIterator<Item = impl Into<String>>,
+    ) -> DkimSigner<T, Done> {
+        self.template.h = headers.into_iter().map(|h| h.into()).collect();
+        DkimSigner {
+            _state: Default::default(),
+            key: self.key,
+            template: self.template,
+        }
+    }
+}
+
+impl<T: SigningKey> DkimSigner<T, Done> {
+    pub fn body_length(mut self, body_length: bool) -> Self {
+        self.template.l = u64::from(body_length);
+        self
+    }
+
+    pub fn header_canonicalization(mut self, ch: Canonicalization) -> Self {
+        self.template.ch = ch;
+        self
+    }
+
+    pub fn body_canonicalization(mut self, cb: Canonicalization) -> Self {
+        self.template.cb = cb;
+        self
+    }
+}

--- a/mini-mail-auth/src/dkim/canonicalize.rs
+++ b/mini-mail-auth/src/dkim/canonicalize.rs
@@ -1,0 +1,167 @@
+use super::{Canonicalization, Signature};
+use crate::common::headers::{HeaderStream, Writable, Writer};
+
+pub struct CanonicalBody<'a> {
+    canonicalization: Canonicalization,
+    body: &'a [u8],
+}
+
+impl Writable for CanonicalBody<'_> {
+    fn write(self, hasher: &mut impl Writer) {
+        let mut crlf_seq = 0;
+        match self.canonicalization {
+            Canonicalization::Relaxed => {
+                let mut last_ch = 0;
+                let mut is_empty = true;
+                for &ch in self.body {
+                    match ch {
+                        b' ' | b'\t' => {
+                            while crlf_seq > 0 {
+                                hasher.write(b"\r\n");
+                                crlf_seq -= 1;
+                            }
+                            is_empty = false;
+                        }
+                        b'\n' => crlf_seq += 1,
+                        b'\r' => {}
+                        _ => {
+                            while crlf_seq > 0 {
+                                hasher.write(b"\r\n");
+                                crlf_seq -= 1;
+                            }
+                            if last_ch == b' ' || last_ch == b'\t' {
+                                hasher.write(b" ");
+                            }
+                            hasher.write(&[ch]);
+                            is_empty = false;
+                        }
+                    }
+                    last_ch = ch;
+                }
+                if !is_empty {
+                    hasher.write(b"\r\n");
+                }
+            }
+            Canonicalization::Simple => {
+                for &ch in self.body {
+                    match ch {
+                        b'\n' => crlf_seq += 1,
+                        b'\r' => {}
+                        _ => {
+                            while crlf_seq > 0 {
+                                hasher.write(b"\r\n");
+                                crlf_seq -= 1;
+                            }
+                            hasher.write(&[ch]);
+                        }
+                    }
+                }
+                if crlf_seq == 0 && !self.body.is_empty() {
+                    hasher.write(b"\r\n");
+                }
+            }
+        }
+    }
+}
+
+impl Canonicalization {
+    pub fn canonicalize_headers<'a>(
+        &self,
+        headers: impl Iterator<Item = (&'a [u8], &'a [u8])>,
+        hasher: &mut impl Writer,
+    ) {
+        match self {
+            Canonicalization::Relaxed => {
+                for (name, value) in headers {
+                    for &ch in name {
+                        if !ch.is_ascii_whitespace() {
+                            hasher.write(&[ch.to_ascii_lowercase()]);
+                        }
+                    }
+                    hasher.write(b":");
+                    let mut bw = 0;
+                    let mut last_ch = 0;
+                    for &ch in value {
+                        if !ch.is_ascii_whitespace() {
+                            if [b' ', b'\t'].contains(&last_ch) && bw > 0 {
+                                hasher.write_len(b" ", &mut bw);
+                            }
+                            hasher.write_len(&[ch], &mut bw);
+                        }
+                        last_ch = ch;
+                    }
+                    if last_ch == b'\n' {
+                        hasher.write(b"\r\n");
+                    }
+                }
+            }
+            Canonicalization::Simple => {
+                for (name, value) in headers {
+                    hasher.write(name);
+                    hasher.write(b":");
+                    hasher.write(value);
+                }
+            }
+        }
+    }
+
+    pub fn canonical_headers<'a>(&self, headers: Vec<(&'a [u8], &'a [u8])>) -> CanonicalHeaders<'a> {
+        CanonicalHeaders { canonicalization: *self, headers }
+    }
+
+    pub fn canonical_body<'a>(&self, body: &'a [u8], l: u64) -> CanonicalBody<'a> {
+        CanonicalBody {
+            canonicalization: *self,
+            body: if l == 0 || body.is_empty() { body } else { &body[..std::cmp::min(l as usize, body.len())] },
+        }
+    }
+
+    pub fn serialize_name(&self, writer: &mut impl Writer) {
+        writer.write(match self {
+            Canonicalization::Relaxed => b"relaxed",
+            Canonicalization::Simple => b"simple",
+        });
+    }
+}
+
+impl Signature {
+    pub fn canonicalize<'x>(
+        &self,
+        mut message: impl HeaderStream<'x>,
+    ) -> (usize, CanonicalHeaders<'x>, Vec<String>, CanonicalBody<'x>) {
+        let mut headers = Vec::with_capacity(self.h.len());
+        let mut found_headers = vec![false; self.h.len()];
+        let mut signed_headers = Vec::with_capacity(self.h.len());
+
+        while let Some((name, value)) = message.next_header() {
+            if let Some(pos) = self.h.iter().position(|header| name.eq_ignore_ascii_case(header.as_bytes())) {
+                headers.push((name, value));
+                found_headers[pos] = true;
+                signed_headers.push(std::str::from_utf8(name).unwrap().into());
+            }
+        }
+
+        let body = message.body();
+        let body_len = body.len();
+        let canonical_headers = self.ch.canonical_headers(headers);
+        let canonical_body = self.ch.canonical_body(body, u64::MAX);
+
+        signed_headers.reverse();
+        for (header, found) in self.h.iter().zip(found_headers) {
+            if !found { signed_headers.push(header.to_string()); }
+        }
+
+        (body_len, canonical_headers, signed_headers, canonical_body)
+    }
+}
+
+pub struct CanonicalHeaders<'a> {
+    canonicalization: Canonicalization,
+    headers: Vec<(&'a [u8], &'a [u8])>,
+}
+
+impl Writable for CanonicalHeaders<'_> {
+    fn write(self, writer: &mut impl Writer) {
+        self.canonicalization.canonicalize_headers(self.headers.into_iter().rev(), writer)
+    }
+}

--- a/mini-mail-auth/src/dkim/headers.rs
+++ b/mini-mail-auth/src/dkim/headers.rs
@@ -1,0 +1,85 @@
+use super::{Algorithm, Canonicalization, Signature};
+use crate::common::headers::{HeaderWriter, Writer};
+use std::fmt::{Display, Formatter};
+
+impl Signature {
+    pub fn write(&self, writer: &mut impl Writer, as_header: bool) {
+        let (header, new_line) = match self.ch {
+            Canonicalization::Relaxed if !as_header => (&b"dkim-signature:"[..], &b" "[..]),
+            _ => (&b"DKIM-Signature: "[..], &b"\r\n\t"[..]),
+        };
+        writer.write(header);
+        writer.write(b"v=1; a=");
+        writer.write(match self.a {
+            Algorithm::RsaSha256 => b"rsa-sha256",
+        });
+        for (tag, value) in [(&b"; s="[..], &self.s), (&b"; d="[..], &self.d)] {
+            writer.write(tag);
+            writer.write(value.as_bytes());
+        }
+        writer.write(b"; c=");
+        self.ch.serialize_name(writer);
+        writer.write(b"/");
+        self.cb.serialize_name(writer);
+
+        writer.write(b";");
+        writer.write(new_line);
+
+        let mut bw = 1;
+        for (num, h) in self.h.iter().enumerate() {
+            if bw + h.len() + 1 >= 76 {
+                writer.write(new_line);
+                bw = 1;
+            }
+            if num > 0 {
+                writer.write_len(b":", &mut bw);
+            } else {
+                writer.write_len(b"h=", &mut bw);
+            }
+            writer.write_len(h.as_bytes(), &mut bw);
+        }
+
+        if self.t > 0 {
+            let value = self.t.to_string();
+            writer.write_len(b";", &mut bw);
+            if bw + 2 + value.len() >= 76 {
+                writer.write(new_line);
+                bw = 1;
+            } else {
+                writer.write_len(b" ", &mut bw);
+            }
+            writer.write_len(b"t=", &mut bw);
+            writer.write_len(value.as_bytes(), &mut bw);
+        }
+
+        for (tag, value) in [(&b"; bh="[..], &self.bh), (&b"; b="[..], &self.b)] {
+            writer.write_len(tag, &mut bw);
+            for &byte in value {
+                writer.write_len(&[byte], &mut bw);
+                if bw >= 76 {
+                    writer.write(new_line);
+                    bw = 1;
+                }
+            }
+        }
+
+        writer.write(b";");
+        if as_header {
+            writer.write(b"\r\n");
+        }
+    }
+}
+
+impl HeaderWriter for Signature {
+    fn write_header(&self, writer: &mut impl Writer) {
+        self.write(writer, true);
+    }
+}
+
+impl Display for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut buf = Vec::new();
+        self.write(&mut buf, false);
+        f.write_str(&String::from_utf8_lossy(&buf))
+    }
+}

--- a/mini-mail-auth/src/dkim/mod.rs
+++ b/mini-mail-auth/src/dkim/mod.rs
@@ -1,0 +1,40 @@
+use crate::common::crypto::{Algorithm, SigningKey};
+use std::marker::PhantomData;
+
+// --- Enums and Structs ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Canonicalization {
+    #[default]
+    Relaxed,
+    Simple,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct Signature {
+    pub v: u32,
+    pub a: Algorithm,
+    pub d: String,
+    pub s: String,
+    pub b: Vec<u8>,
+    pub bh: Vec<u8>,
+    pub h: Vec<String>,
+    pub l: u64,
+    pub t: u64,
+    pub ch: Canonicalization,
+    pub cb: Canonicalization,
+}
+
+// --- Builder Pattern ---
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct DkimSigner<T: SigningKey, State = NeedDomain> {
+    pub(crate) _state: PhantomData<State>,
+    pub(crate) key: T,
+    pub(crate) template: Signature,
+}
+
+pub struct NeedDomain;
+pub struct NeedSelector;
+pub struct NeedHeaders;
+pub struct Done;

--- a/mini-mail-auth/src/dkim/sign.rs
+++ b/mini-mail-auth/src/dkim/sign.rs
@@ -1,0 +1,66 @@
+use super::{canonicalize::CanonicalHeaders, DkimSigner, Done, Signature};
+use crate::{
+    common::{
+        crypto::SigningKey,
+        headers::{HeaderIterator, HeaderStream, Writable, Writer},
+    },
+    Error,
+};
+use std::time::{SystemTime};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+
+
+impl<T: SigningKey> DkimSigner<T, Done> {
+    pub fn sign(&self, message: &[u8]) -> crate::Result<Signature> {
+        self.sign_stream(
+            HeaderIterator::new(message),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        )
+    }
+
+    fn sign_stream<'x>(
+        &self,
+        message: impl HeaderStream<'x>,
+        now: u64,
+    ) -> crate::Result<Signature> {
+        let (body_len, canonical_headers, signed_headers, canonical_body) =
+            self.template.canonicalize(message);
+
+        if signed_headers.is_empty() {
+            return Err(Error::NoHeadersFound);
+        }
+
+        let mut signature = self.template.clone();
+        let body_hash = self.key.hash(canonical_body);
+        signature.bh = BASE64_STANDARD.encode(body_hash.as_ref()).into_bytes();
+        signature.t = now;
+        signature.h = signed_headers;
+        if signature.l > 0 {
+            signature.l = body_len as u64;
+        }
+
+        let b = self.key.sign(SignableMessage {
+            headers: canonical_headers,
+            signature: &signature,
+        })?;
+
+        signature.b = BASE64_STANDARD.encode(&b).into_bytes();
+
+        Ok(signature)
+    }
+}
+
+pub(super) struct SignableMessage<'a> {
+    headers: CanonicalHeaders<'a>,
+    signature: &'a Signature,
+}
+
+impl Writable for SignableMessage<'_> {
+    fn write(self, writer: &mut impl Writer) {
+        self.headers.write(writer);
+        self.signature.write(writer, false);
+    }
+}

--- a/mini-mail-auth/src/lib.rs
+++ b/mini-mail-auth/src/lib.rs
@@ -1,0 +1,65 @@
+//! A minimal DKIM signing library for Rust.
+
+// Module declarations
+pub mod common;
+pub mod dkim;
+
+// Re-export the main signer struct and other necessary components.
+pub use dkim::{DkimSigner, Signature};
+pub use common::crypto::{RsaKey, Sha256};
+pub use common::headers::HeaderWriter;
+
+/// A simplified function to sign an email with an RSA-SHA256 DKIM signature.
+///
+/// # Arguments
+///
+/// * `email` - The full email content (headers and body) as a string slice.
+/// * `domain` - The signing domain (e.g., "example.com").
+/// * `selector` - The DKIM selector (e.g., "default").
+/// * `private_key` - The RSA private key in PKCS#1 PEM format.
+///
+/// # Returns
+///
+/// A `String` containing the DKIM signature header prepended to the original email.
+pub fn sign_email(email: &str, domain: &str, selector: &str, private_key: &str) -> String {
+    // Sign an e-mail message using RSA-SHA256
+    let pk_rsa = RsaKey::<Sha256>::from_pkcs1_pem(private_key).unwrap();
+    let signature_rsa = DkimSigner::from_key(pk_rsa)
+        .domain(domain)
+        .selector(selector)
+        .headers(["From", "To", "Subject"])
+        .sign(email.as_bytes())
+        .unwrap();
+
+    format!("{}{}", signature_rsa.to_header(), email)
+}
+
+
+/// A minimal error type for the library.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    NoHeadersFound,
+    CryptoError(String),
+    Base64,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NoHeadersFound => write!(f, "No headers found to sign"),
+            Error::CryptoError(err) => write!(f, "Cryptography error: {err}"),
+            Error::Base64 => write!(f, "Base64 encoding error."),
+        }
+    }
+}
+
+// Convert from rsa::errors::Error to our custom Error type.
+impl From<rsa::errors::Error> for Error {
+    fn from(err: rsa::errors::Error) -> Self {
+        Error::CryptoError(err.to_string())
+    }
+}


### PR DESCRIPTION
This commit creates the mini-mail-auth crate, a lightweight version of the mail-auth crate focused solely on DKIM signing.